### PR TITLE
Fix missing route error in juggle script

### DIFF
--- a/tools/plotjuggler/juggle.py
+++ b/tools/plotjuggler/juggle.py
@@ -137,5 +137,7 @@ if __name__ == "__main__":
   if args.stream:
     start_juggler(layout=args.layout)
   else:
-    route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name.strip()
-    juggle_route(route_or_segment_name, args.can, args.layout, args.dbc, not args.no_migration)
+    route_or_segment_name = DEMO_ROUTE if args.demo else args.route_or_segment_name
+    if route_or_segment_name is None:
+      parser.error("route_or_segment_name is required unless using --demo or --stream")
+    juggle_route(route_or_segment_name.strip(), args.can, args.layout, args.dbc, not args.no_migration)


### PR DESCRIPTION
## Summary
- protect route parsing in juggle.py when no route is provided

## Testing
- `python3 -m py_compile tools/plotjuggler/juggle.py`
- `pytest tools/plotjuggler/test_plotjuggler.py::TestPlotJuggler::test_layouts -q` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*