### PR TITLE
model manager: bump selector version 13→15 and switch to v15 model list

### DIFF
--- a/sunnypilot/models/fetcher.py
+++ b/sunnypilot/models/fetcher.py
@@ -116,7 +116,7 @@ class ModelCache:
 
 class ModelFetcher:
   """Handles fetching and caching of model data from remote source"""
-  MODEL_URL = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-docs/refs/heads/gh-pages/docs/driving_models_v10.json"
+  MODEL_URL = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-docs/refs/heads/gh-pages/docs/driving_models_v15.json"
 
   def __init__(self, params: Params):
     self.params = params

--- a/sunnypilot/models/helpers.py
+++ b/sunnypilot/models/helpers.py
@@ -19,8 +19,8 @@ from openpilot.system.hardware.hw import Paths
 from pathlib import Path
 
 # see the README.md for more details on the model selector versioning
-CURRENT_SELECTOR_VERSION = 13
-REQUIRED_MIN_SELECTOR_VERSION = 12
+CURRENT_SELECTOR_VERSION = 15
+REQUIRED_MIN_SELECTOR_VERSION = 14
 
 USE_ONNX = os.getenv('USE_ONNX', PC)
 

--- a/sunnypilot/models/manager.py
+++ b/sunnypilot/models/manager.py
@@ -63,6 +63,9 @@ class ModelManagerSP:
             f.write(chunk)
             bytes_downloaded += len(chunk)
 
+            if not self.params.get("ModelManager_DownloadIndex"):
+              raise Exception("Download cancelled")
+
             if total_size > 0:
               progress = (bytes_downloaded / total_size) * 100
               model.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloading
@@ -168,7 +171,7 @@ class ModelManagerSP:
         self.available_models = self.model_fetcher.get_available_bundles()
         self.active_bundle = get_active_bundle(self.params)
 
-        if index_to_download := self.params.get("ModelManager_DownloadIndex"):
+        if (index_to_download := self.params.get("ModelManager_DownloadIndex")) is not None:
           if model_to_download := next((model for model in self.available_models if model.index == index_to_download), None):
             try:
               self.download(model_to_download, Paths.model_root())
@@ -176,6 +179,7 @@ class ModelManagerSP:
               cloudlog.exception(e)
             finally:
               self.params.remove("ModelManager_DownloadIndex")
+              self.selected_bundle = None
 
         if self.params.get("ModelManager_ClearCache"):
             self.clear_model_cache()


### PR DESCRIPTION
## Summary
- Bump model selector version from 13→15 and minimum required version from 12→14
- Switch model list URL from `driving_models_v10.json` to `driving_models_v15.json`
- Add download cancellation support: abort download when `ModelManager_DownloadIndex` param is cleared
- Fix download index check to use `is not None` so falsy index values (e.g. `0`) aren't skipped
- Reset `selected_bundle` after download completes

## Test plan
- [ ] Verify model list loads from v15 endpoint
- [ ] Test model download and cancellation
- [ ] Confirm model with index 0 can be downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)